### PR TITLE
270 Logs from Planks Carpentry

### DIFF
--- a/src/main/java/com/anedhel/vext/datagen/ModRecipeProvider.java
+++ b/src/main/java/com/anedhel/vext/datagen/ModRecipeProvider.java
@@ -650,7 +650,7 @@ public class ModRecipeProvider extends FabricRecipeProvider {
 					createCarpentryRecipe(category, entry.getValue(), family.getBaseBlock(), count);
 				}
 				for(Block block : filteredBaseBlocks) {
-					createCarpentryRecipe(RecipeCategory.BUILDING_BLOCKS, block, family.getBaseBlock(), 4);
+					createCarpentryRecipe(RecipeCategory.BUILDING_BLOCKS, family.getBaseBlock(), block, 4);
 					for(Map.Entry<BlockFamily.Variant, Block> entry : family.getVariants().entrySet()) {
 						if(EXCLUDED_CARPENTRY_VARIANTS.contains(entry.getKey())) {
 							continue;


### PR DESCRIPTION
Fixed the issue, that logs could be crafted from Planks on the Carpentry Table